### PR TITLE
Upgrade rubico to v1.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6621,9 +6621,9 @@
       }
     },
     "rubico": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/rubico/-/rubico-1.5.8.tgz",
-      "integrity": "sha512-huocGR6q6szPIwM15tiU2MNPGjSEzPYoJZd9R9mUjlYKy2r7mH/r5qBvyW7Xj03kJnAASSJEiCjCD4+XnUst2g=="
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/rubico/-/rubico-1.6.8.tgz",
+      "integrity": "sha512-sRtCGkJEbO2XZIi6aa7kHDTITJkOzkZa80T+3lZjRgP9EDw71zQN0R+5gUWnUZCxkHKRLRH8H1Bvo9ZXftkqZA=="
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prompts": "^2.3.2",
     "querystring": "^0.2.0",
     "remedial": "^1.0.8",
-    "rubico": "^1.5.8",
+    "rubico": "^1.6.8",
     "rxjs": "^6.6.0",
     "shelljs": "^0.8.4",
     "shortid": "^2.2.15",

--- a/src/providers/CoreProvider.js
+++ b/src/providers/CoreProvider.js
@@ -1225,7 +1225,7 @@ function CoreProvider({
               nextState: "ERROR",
               error,
             });
-            return { error, resource: resource.toJSON() };
+            return [{ error, resource: resource.toJSON() }];
           }
         )
       ),

--- a/src/providers/Planner.js
+++ b/src/providers/Planner.js
@@ -26,11 +26,11 @@ exports.mapToGraph = pipe([
   (mapResource) =>
     map((resource) => {
       const dependsOn = transform(
-        flatMap((resource) =>
+        map((resource) =>
           resource.name
             ? [resource.name]
             : transform(
-                map((dep) => dep.name),
+                map((dep) => [dep.name]),
                 () => []
               )(resource)
         ),

--- a/src/providers/aws/EC2/AwsEC2.js
+++ b/src/providers/aws/EC2/AwsEC2.js
@@ -187,7 +187,7 @@ module.exports = AwsEC2 = ({ spec, config }) => {
         DeviceIndex: 0,
         ...(!isEmpty(securityGroups) && {
           Groups: transform(
-            map((sg) => getField(sg, "GroupId")),
+            map((sg) => [getField(sg, "GroupId")]),
             () => []
           )(securityGroups),
         }),

--- a/src/providers/mock/MockCloud.js
+++ b/src/providers/mock/MockCloud.js
@@ -43,7 +43,7 @@ module.exports = MockCloud = (initStates = []) => {
   logger.debug(`MockCloud ${tos(initStates)}`);
   initStates = defaultsDeep(mockCloudInitStatesDefault)(initStates);
   const states = transform(
-    map((state) => [state[0], new Map(copyDeep(state[1] || []))]),
+    map((state) => [[state[0], new Map(copyDeep(state[1] || []))]]),
     () => []
   )(initStates);
   const resourceMap = new Map(states);


### PR DESCRIPTION
This PR upgrades rubico from v1.5.8 to v1.6.8. Some major features of the new rubico minor

  * Better performance all around
  * `curry`, `__`, `thunkify`, `always` are now available as part of rubico core
  * `differenceWith` in rubico/x

this upgrade wasn't the smoothest because of two reasons on rubico's part

  * `assign` was using the function `promiseObjectAll` internally which, when I revisited, made more sense to just cut out and use an algorithm similar to the v1.5.8 `assign`. The original reason was performance (avoids creating an additional scope), but now curry has made this not necessary

  * `assign` was mutating the original result (this is actually fine in v1.5.8) only when it was async. That would break with this code due to creation of a circular reference

```javascript
                    assign({
                      result: async ({ provider, result }) =>
                        provider.planDestroy({
                          plans: result.plans,
                          onStateChange,
                        }),
                    }),

```

The above code is fine to use now. The other changes are just some flattening behavior that could be more consistent.