### PR TITLE
Added "Edit this page" link to docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -107,7 +107,9 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          // Please change this to your repo.
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/grucloud/grucloud/main/editor/docusaurus/docs/${docPath}`
+          },
         },
         gtag: {
           trackingID: "UA-179962442-1",


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/grucloud/grucloud/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb